### PR TITLE
Adding ability to run tests and hook into travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+script:
+  python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,10 @@ def main():
           'pyusb',
           'usbinfo>=1.1'
       ],
+      setup_requires=['pytest-runner'],
+      tests_require=[
+          'pytest',
+      ],
   )
 
   setup(**setup_data)


### PR DESCRIPTION
Added a new setup alias, and test dependencies, so that
we can run tests via:

  python setup.py test

And use this to create a travis-CI job.